### PR TITLE
Update dependency jest to v23.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -677,6 +677,29 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-istanbul": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "find-up": "2.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "test-exclude": "4.2.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
     "babel-plugin-jest-hoist": {
       "version": "23.0.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.0.1.tgz",
@@ -1822,6 +1845,31 @@
       "dev": true,
       "requires": {
         "fill-range": "^2.1.0"
+      }
+    },
+    "expect": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-23.1.0.tgz",
+      "integrity": "sha1-v9/VeiogFw2HWZnul4fMcfAcIF8=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "jest-diff": "23.0.1",
+        "jest-get-type": "22.4.3",
+        "jest-matcher-utils": "23.0.1",
+        "jest-message-util": "23.1.0",
+        "jest-regex-util": "23.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
       }
     },
     "extend": {
@@ -3734,6 +3782,19 @@
         }
       }
     },
+    "istanbul-lib-source-maps": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
+      "integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "istanbul-lib-coverage": "1.2.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "source-map": "0.5.7"
+      }
+    },
     "istanbul-reports": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
@@ -3744,88 +3805,19 @@
       }
     },
     "jest": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-23.0.1.tgz",
-      "integrity": "sha1-DQgykO5BEs7Pt4Dfb/gTMu03MgE=",
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-23.1.0.tgz",
+      "integrity": "sha1-u7f4kxAKEadC3YvQ0EelSwlorRo=",
       "dev": true,
       "requires": {
         "import-local": "1.0.0",
-        "jest-cli": "23.0.1"
+        "jest-cli": "23.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.4.tgz",
-          "integrity": "sha512-UzuK0g1wyQijiaYQxj/CdNycFhAd2TLtO2obKQMTZrZ1jzEMRY3rvpASEKkaxbRR6brvdovfA03znPa/pXcejg==",
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "jest-changed-files": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.0.1.tgz",
-          "integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
-          "dev": true,
-          "requires": {
-            "throat": "4.1.0"
-          }
-        },
         "jest-cli": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.0.1.tgz",
-          "integrity": "sha1-NRpbpRzyjs8gM22XowuXDR9TClY=",
+          "version": "23.1.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.1.0.tgz",
+          "integrity": "sha1-64vdTODRUlCJLjGtm2m8mdKo9r8=",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
@@ -3838,20 +3830,21 @@
             "istanbul-api": "1.3.1",
             "istanbul-lib-coverage": "1.2.0",
             "istanbul-lib-instrument": "1.10.1",
-            "istanbul-lib-source-maps": "1.2.4",
+            "istanbul-lib-source-maps": "1.2.5",
             "jest-changed-files": "23.0.1",
-            "jest-config": "23.0.1",
-            "jest-environment-jsdom": "23.0.1",
+            "jest-config": "23.1.0",
+            "jest-environment-jsdom": "23.1.0",
             "jest-get-type": "22.4.3",
-            "jest-haste-map": "23.0.1",
-            "jest-message-util": "23.0.0",
+            "jest-haste-map": "23.1.0",
+            "jest-message-util": "23.1.0",
             "jest-regex-util": "23.0.0",
             "jest-resolve-dependencies": "23.0.1",
-            "jest-runner": "23.0.1",
-            "jest-runtime": "23.0.1",
+            "jest-runner": "23.1.0",
+            "jest-runtime": "23.1.0",
             "jest-snapshot": "23.0.1",
-            "jest-util": "23.0.1",
+            "jest-util": "23.1.0",
             "jest-validate": "23.0.1",
+            "jest-watcher": "23.1.0",
             "jest-worker": "23.0.1",
             "micromatch": "2.3.11",
             "node-notifier": "5.2.1",
@@ -3864,359 +3857,157 @@
             "yargs": "11.0.0"
           }
         },
-        "jest-diff": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
-          "integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
+        "jest-config": {
+          "version": "23.1.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.1.0.tgz",
+          "integrity": "sha1-cIyg9DHTVu5CT7SJXTMIAGvdgkE=",
           "dev": true,
           "requires": {
+            "babel-core": "6.26.0",
+            "babel-jest": "23.0.1",
             "chalk": "2.3.1",
-            "diff": "3.5.0",
+            "glob": "7.1.2",
+            "jest-environment-jsdom": "23.1.0",
+            "jest-environment-node": "23.1.0",
             "jest-get-type": "22.4.3",
-            "pretty-format": "23.0.1"
-          }
-        },
-        "jest-docblock": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.0.1.tgz",
-          "integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
-          "dev": true,
-          "requires": {
-            "detect-newline": "2.1.0"
-          }
-        },
-        "jest-environment-jsdom": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.0.1.tgz",
-          "integrity": "sha1-2mieuTWNwW5XCKuyCPTrJqQ5V1w=",
-          "dev": true,
-          "requires": {
-            "jest-mock": "23.0.1",
-            "jest-util": "23.0.1",
-            "jsdom": "11.6.2"
-          }
-        },
-        "jest-haste-map": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.0.1.tgz",
-          "integrity": "sha1-zYkFKr/Iy6AfVgu+wJ1PNq7CXU8=",
-          "dev": true,
-          "requires": {
-            "fb-watchman": "2.0.0",
-            "graceful-fs": "4.1.11",
-            "jest-docblock": "23.0.1",
-            "jest-serializer": "23.0.1",
-            "jest-worker": "23.0.1",
-            "micromatch": "2.3.11",
-            "sane": "2.5.0"
-          }
-        },
-        "jest-matcher-utils": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
-          "integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.1",
-            "jest-get-type": "22.4.3",
-            "pretty-format": "23.0.1"
-          }
-        },
-        "jest-message-util": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.0.0.tgz",
-          "integrity": "sha1-Bz89dscB98cYpLmvHrfxOHksR5Y=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.42",
-            "chalk": "2.3.1",
-            "micromatch": "2.3.11",
-            "slash": "1.0.0",
-            "stack-utils": "1.0.1"
-          }
-        },
-        "jest-mock": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.0.1.tgz",
-          "integrity": "sha1-FWn0d5aMZo/HKCc6F8N2d3O0Y1c=",
-          "dev": true
-        },
-        "jest-regex-util": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-          "integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
-          "dev": true
-        },
-        "jest-resolve-dependencies": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz",
-          "integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
-          "dev": true,
-          "requires": {
+            "jest-jasmine2": "23.1.0",
             "jest-regex-util": "23.0.0",
-            "jest-snapshot": "23.0.1"
-          }
-        },
-        "jest-serializer": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-          "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
-          "dev": true
-        },
-        "jest-snapshot": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
-          "integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.1",
-            "jest-diff": "23.0.1",
-            "jest-matcher-utils": "23.0.1",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
+            "jest-resolve": "23.1.0",
+            "jest-util": "23.1.0",
+            "jest-validate": "23.0.1",
             "pretty-format": "23.0.1"
           }
         },
-        "jest-util": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.0.1.tgz",
-          "integrity": "sha1-aOpb1+2xd9MFn5eXJZ+ODazOL5k=",
+        "jest-each": {
+          "version": "23.1.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.1.0.tgz",
+          "integrity": "sha1-FhRrWSw1SGelrl4TzfFcbGW2lsY=",
           "dev": true,
           "requires": {
-            "callsites": "2.0.0",
             "chalk": "2.3.1",
+            "pretty-format": "23.0.1"
+          }
+        },
+        "jest-jasmine2": {
+          "version": "23.1.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz",
+          "integrity": "sha1-SvqzFym2VN3NKwdK3YSTlvE7MLg=",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1",
+            "co": "4.6.0",
+            "expect": "23.1.0",
+            "is-generator-fn": "1.0.0",
+            "jest-diff": "23.0.1",
+            "jest-each": "23.1.0",
+            "jest-matcher-utils": "23.0.1",
+            "jest-message-util": "23.1.0",
+            "jest-snapshot": "23.0.1",
+            "jest-util": "23.1.0",
+            "pretty-format": "23.0.1"
+          }
+        },
+        "jest-runner": {
+          "version": "23.1.0",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.1.0.tgz",
+          "integrity": "sha1-+iCpM//3MaVDKzVh5/ZCZZT6KbU=",
+          "dev": true,
+          "requires": {
+            "exit": "0.1.2",
             "graceful-fs": "4.1.11",
-            "is-ci": "1.1.0",
-            "jest-message-util": "23.0.0",
-            "mkdirp": "0.5.1",
-            "source-map": "0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-              "dev": true
-            }
+            "jest-config": "23.1.0",
+            "jest-docblock": "23.0.1",
+            "jest-haste-map": "23.1.0",
+            "jest-jasmine2": "23.1.0",
+            "jest-leak-detector": "23.0.1",
+            "jest-message-util": "23.1.0",
+            "jest-runtime": "23.1.0",
+            "jest-util": "23.1.0",
+            "jest-worker": "23.0.1",
+            "source-map-support": "0.5.6",
+            "throat": "4.1.0"
           }
         },
-        "jest-worker": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.0.1.tgz",
-          "integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
+        "jest-runtime": {
+          "version": "23.1.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.1.0.tgz",
+          "integrity": "sha1-tK4OhyWeys/UqIS2OdsHz03WIK8=",
           "dev": true,
           "requires": {
-            "merge-stream": "1.0.1"
-          }
-        },
-        "pretty-format": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
-          "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.1"
-          }
-        },
-        "yargs": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
-        }
-      }
-    },
-    "jest-config": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.0.1.tgz",
-      "integrity": "sha1-Z5i/8SR8ejkLEycZMwUAFYL8WPo=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.0",
-        "babel-jest": "23.0.1",
-        "chalk": "2.3.1",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "23.0.1",
-        "jest-environment-node": "23.0.1",
-        "jest-get-type": "22.4.3",
-        "jest-jasmine2": "23.0.1",
-        "jest-regex-util": "23.0.0",
-        "jest-resolve": "23.0.1",
-        "jest-util": "23.0.1",
-        "jest-validate": "23.0.1",
-        "pretty-format": "23.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        },
-        "jest-environment-jsdom": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.0.1.tgz",
-          "integrity": "sha1-2mieuTWNwW5XCKuyCPTrJqQ5V1w=",
-          "dev": true,
-          "requires": {
-            "jest-mock": "23.0.1",
-            "jest-util": "23.0.1",
-            "jsdom": "11.6.2"
-          }
-        },
-        "jest-environment-node": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.0.1.tgz",
-          "integrity": "sha1-Z2t0DiBfHyvnckGWnngSvoJO55U=",
-          "dev": true,
-          "requires": {
-            "jest-mock": "23.0.1",
-            "jest-util": "23.0.1"
-          }
-        },
-        "jest-message-util": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.0.0.tgz",
-          "integrity": "sha1-Bz89dscB98cYpLmvHrfxOHksR5Y=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.42",
+            "babel-core": "6.26.0",
+            "babel-plugin-istanbul": "4.1.6",
             "chalk": "2.3.1",
+            "convert-source-map": "1.5.1",
+            "exit": "0.1.2",
+            "fast-json-stable-stringify": "2.0.0",
+            "graceful-fs": "4.1.11",
+            "jest-config": "23.1.0",
+            "jest-haste-map": "23.1.0",
+            "jest-message-util": "23.1.0",
+            "jest-regex-util": "23.0.0",
+            "jest-resolve": "23.1.0",
+            "jest-snapshot": "23.0.1",
+            "jest-util": "23.1.0",
+            "jest-validate": "23.0.1",
             "micromatch": "2.3.11",
+            "realpath-native": "1.0.0",
             "slash": "1.0.0",
-            "stack-utils": "1.0.1"
+            "strip-bom": "3.0.0",
+            "write-file-atomic": "2.3.0",
+            "yargs": "11.0.0"
           }
-        },
-        "jest-mock": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.0.1.tgz",
-          "integrity": "sha1-FWn0d5aMZo/HKCc6F8N2d3O0Y1c=",
-          "dev": true
-        },
-        "jest-regex-util": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-          "integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
-          "dev": true
-        },
-        "jest-resolve": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.0.1.tgz",
-          "integrity": "sha1-P4QDRisQo0wt8dR6q1V0xJNbzSQ=",
-          "dev": true,
-          "requires": {
-            "browser-resolve": "1.11.2",
-            "chalk": "2.3.1",
-            "realpath-native": "1.0.0"
-          }
-        },
-        "jest-util": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.0.1.tgz",
-          "integrity": "sha1-aOpb1+2xd9MFn5eXJZ+ODazOL5k=",
-          "dev": true,
-          "requires": {
-            "callsites": "2.0.0",
-            "chalk": "2.3.1",
-            "graceful-fs": "4.1.11",
-            "is-ci": "1.1.0",
-            "jest-message-util": "23.0.0",
-            "mkdirp": "0.5.1",
-            "source-map": "0.6.1"
-          }
-        },
-        "pretty-format": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
-          "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
         }
       }
     },
-    "jest-each": {
+    "jest-changed-files": {
       "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.0.1.tgz",
-      "integrity": "sha1-puXb9TCvxr+ddHkt3mnY23D4RwY=",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.0.1.tgz",
+      "integrity": "sha1-95Vy0HIIROpd+EwqRI6GLCJU9gw=",
+      "dev": true,
+      "requires": {
+        "throat": "4.1.0"
+      }
+    },
+    "jest-diff": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
+      "integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
       "dev": true,
       "requires": {
         "chalk": "2.3.1",
+        "diff": "3.5.0",
+        "jest-get-type": "22.4.3",
         "pretty-format": "23.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "pretty-format": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
-          "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.1"
-          }
-        }
+      }
+    },
+    "jest-docblock": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.0.1.tgz",
+      "integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
+      "dev": true,
+      "requires": {
+        "detect-newline": "2.1.0"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz",
+      "integrity": "sha1-hZKZFOI77TV32sl1X0EG0Gl8R5w=",
+      "dev": true,
+      "requires": {
+        "jest-mock": "23.1.0",
+        "jest-util": "23.1.0",
+        "jsdom": "11.6.2"
+      }
+    },
+    "jest-environment-node": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.1.0.tgz",
+      "integrity": "sha1-RSwL+UnPy7rNoeF2Lu7XC8eEx9U=",
+      "dev": true,
+      "requires": {
+        "jest-mock": "23.1.0",
+        "jest-util": "23.1.0"
       }
     },
     "jest-get-type": {
@@ -4225,548 +4016,134 @@
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
-    "jest-jasmine2": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.0.1.tgz",
-      "integrity": "sha1-Fth1NW5jYIcrukhCb30x/cGwvOo=",
+    "jest-haste-map": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.1.0.tgz",
+      "integrity": "sha1-GObH1ajScTb5G32YUvhd4McHTEk=",
       "dev": true,
       "requires": {
-        "chalk": "2.3.1",
-        "co": "4.6.0",
-        "expect": "23.0.1",
-        "is-generator-fn": "1.0.0",
-        "jest-diff": "23.0.1",
-        "jest-each": "23.0.1",
-        "jest-matcher-utils": "23.0.1",
-        "jest-message-util": "23.0.0",
-        "jest-snapshot": "23.0.1",
-        "jest-util": "23.0.1",
-        "pretty-format": "23.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        },
-        "expect": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-23.0.1.tgz",
-          "integrity": "sha1-mRMfL9kRVZX4zDaXQB5/BzTUX+8=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "jest-diff": "23.0.1",
-            "jest-get-type": "22.4.3",
-            "jest-matcher-utils": "23.0.1",
-            "jest-message-util": "23.0.0",
-            "jest-regex-util": "23.0.0"
-          }
-        },
-        "jest-diff": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
-          "integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.1",
-            "diff": "3.5.0",
-            "jest-get-type": "22.4.3",
-            "pretty-format": "23.0.1"
-          }
-        },
-        "jest-matcher-utils": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
-          "integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.1",
-            "jest-get-type": "22.4.3",
-            "pretty-format": "23.0.1"
-          }
-        },
-        "jest-message-util": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.0.0.tgz",
-          "integrity": "sha1-Bz89dscB98cYpLmvHrfxOHksR5Y=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.42",
-            "chalk": "2.3.1",
-            "micromatch": "2.3.11",
-            "slash": "1.0.0",
-            "stack-utils": "1.0.1"
-          }
-        },
-        "jest-regex-util": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-          "integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
-          "dev": true
-        },
-        "jest-snapshot": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
-          "integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.1",
-            "jest-diff": "23.0.1",
-            "jest-matcher-utils": "23.0.1",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "pretty-format": "23.0.1"
-          }
-        },
-        "jest-util": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.0.1.tgz",
-          "integrity": "sha1-aOpb1+2xd9MFn5eXJZ+ODazOL5k=",
-          "dev": true,
-          "requires": {
-            "callsites": "2.0.0",
-            "chalk": "2.3.1",
-            "graceful-fs": "4.1.11",
-            "is-ci": "1.1.0",
-            "jest-message-util": "23.0.0",
-            "mkdirp": "0.5.1",
-            "source-map": "0.6.1"
-          }
-        },
-        "pretty-format": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
-          "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "jest-runner": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.0.1.tgz",
-      "integrity": "sha1-sXauPs+eGUqkuEp/z3DRuNsjGqc=",
-      "dev": true,
-      "requires": {
-        "exit": "0.1.2",
+        "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-config": "23.0.1",
         "jest-docblock": "23.0.1",
-        "jest-haste-map": "23.0.1",
-        "jest-jasmine2": "23.0.1",
-        "jest-leak-detector": "23.0.1",
-        "jest-message-util": "23.0.0",
-        "jest-runtime": "23.0.1",
-        "jest-util": "23.0.1",
+        "jest-serializer": "23.0.1",
         "jest-worker": "23.0.1",
-        "source-map-support": "0.5.6",
-        "throat": "4.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "callsites": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-          "dev": true
-        },
-        "jest-docblock": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.0.1.tgz",
-          "integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
-          "dev": true,
-          "requires": {
-            "detect-newline": "2.1.0"
-          }
-        },
-        "jest-haste-map": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.0.1.tgz",
-          "integrity": "sha1-zYkFKr/Iy6AfVgu+wJ1PNq7CXU8=",
-          "dev": true,
-          "requires": {
-            "fb-watchman": "2.0.0",
-            "graceful-fs": "4.1.11",
-            "jest-docblock": "23.0.1",
-            "jest-serializer": "23.0.1",
-            "jest-worker": "23.0.1",
-            "micromatch": "2.3.11",
-            "sane": "2.5.0"
-          }
-        },
-        "jest-leak-detector": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz",
-          "integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
-          "dev": true,
-          "requires": {
-            "pretty-format": "23.0.1"
-          }
-        },
-        "jest-message-util": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.0.0.tgz",
-          "integrity": "sha1-Bz89dscB98cYpLmvHrfxOHksR5Y=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.42",
-            "chalk": "2.3.1",
-            "micromatch": "2.3.11",
-            "slash": "1.0.0",
-            "stack-utils": "1.0.1"
-          }
-        },
-        "jest-serializer": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-          "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
-          "dev": true
-        },
-        "jest-util": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.0.1.tgz",
-          "integrity": "sha1-aOpb1+2xd9MFn5eXJZ+ODazOL5k=",
-          "dev": true,
-          "requires": {
-            "callsites": "2.0.0",
-            "chalk": "2.3.1",
-            "graceful-fs": "4.1.11",
-            "is-ci": "1.1.0",
-            "jest-message-util": "23.0.0",
-            "mkdirp": "0.5.1",
-            "source-map": "0.6.1"
-          }
-        },
-        "jest-worker": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.0.1.tgz",
-          "integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
-          "dev": true,
-          "requires": {
-            "merge-stream": "1.0.1"
-          }
-        },
-        "pretty-format": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
-          "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-          "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "1.0.0",
-            "source-map": "0.6.1"
-          }
-        }
+        "micromatch": "2.3.11",
+        "sane": "2.5.0"
       }
     },
-    "jest-runtime": {
+    "jest-leak-detector": {
       "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.0.1.tgz",
-      "integrity": "sha1-sddl+wP7bUBDgFrycGdqaT9QTVc=",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.0.1.tgz",
+      "integrity": "sha1-nboHUFrDSVw50+wJrB5WRZnoYaA=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-plugin-istanbul": "4.1.6",
+        "pretty-format": "23.0.1"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
+      "integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
+      "dev": true,
+      "requires": {
         "chalk": "2.3.1",
-        "convert-source-map": "1.5.1",
-        "exit": "0.1.2",
-        "fast-json-stable-stringify": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-config": "23.0.1",
-        "jest-haste-map": "23.0.1",
-        "jest-message-util": "23.0.0",
-        "jest-regex-util": "23.0.0",
-        "jest-resolve": "23.0.1",
-        "jest-snapshot": "23.0.1",
-        "jest-util": "23.0.1",
-        "jest-validate": "23.0.1",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.0.1"
+      }
+    },
+    "jest-message-util": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.1.0.tgz",
+      "integrity": "sha1-moCbpIfsrFzlEdTmmO47XuJGHqk=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.42",
+        "chalk": "2.3.1",
         "micromatch": "2.3.11",
-        "realpath-native": "1.0.0",
         "slash": "1.0.0",
-        "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "11.0.0"
+        "stack-utils": "1.0.1"
+      }
+    },
+    "jest-mock": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.1.0.tgz",
+      "integrity": "sha1-o4HDGxIasfYMRiotrbe4bczKxIc=",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
+      "integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.1.0.tgz",
+      "integrity": "sha1-ueMW7s69bwC8UKOWDRUnuuZXktI=",
+      "dev": true,
+      "requires": {
+        "browser-resolve": "1.11.2",
+        "chalk": "2.3.1",
+        "realpath-native": "1.0.0"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.0.1.tgz",
+      "integrity": "sha1-0BoQ3a2RUsTOzfXqwriFccS2pk0=",
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "23.0.0",
+        "jest-snapshot": "23.0.1"
+      }
+    },
+    "jest-serializer": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
+      "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
+      "dev": true
+    },
+    "jest-snapshot": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
+      "integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.1",
+        "jest-diff": "23.0.1",
+        "jest-matcher-utils": "23.0.1",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "pretty-format": "23.0.1"
+      }
+    },
+    "jest-util": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.1.0.tgz",
+      "integrity": "sha1-wCUbrzRkTG3S/qeKli9CY6xVdy0=",
+      "dev": true,
+      "requires": {
+        "callsites": "2.0.0",
+        "chalk": "2.3.1",
+        "graceful-fs": "4.1.11",
+        "is-ci": "1.1.0",
+        "jest-message-util": "23.1.0",
+        "mkdirp": "0.5.1",
+        "slash": "1.0.0",
+        "source-map": "0.6.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
-        },
-        "babel-plugin-istanbul": {
-          "version": "4.1.6",
-          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
-          "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
-          "dev": true,
-          "requires": {
-            "babel-plugin-syntax-object-rest-spread": "6.13.0",
-            "find-up": "2.1.0",
-            "istanbul-lib-instrument": "1.10.1",
-            "test-exclude": "4.2.1"
-          }
-        },
         "callsites": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "jest-diff": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.0.1.tgz",
-          "integrity": "sha1-PUkTfO4SwyCktNK0pvpugtSRoWo=",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.1",
-            "diff": "3.5.0",
-            "jest-get-type": "22.4.3",
-            "pretty-format": "23.0.1"
-          }
-        },
-        "jest-docblock": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.0.1.tgz",
-          "integrity": "sha1-3t3RgzO+XcJBUmCgTvP86SdrVyU=",
-          "dev": true,
-          "requires": {
-            "detect-newline": "2.1.0"
-          }
-        },
-        "jest-haste-map": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.0.1.tgz",
-          "integrity": "sha1-zYkFKr/Iy6AfVgu+wJ1PNq7CXU8=",
-          "dev": true,
-          "requires": {
-            "fb-watchman": "2.0.0",
-            "graceful-fs": "4.1.11",
-            "jest-docblock": "23.0.1",
-            "jest-serializer": "23.0.1",
-            "jest-worker": "23.0.1",
-            "micromatch": "2.3.11",
-            "sane": "2.5.0"
-          }
-        },
-        "jest-matcher-utils": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.0.1.tgz",
-          "integrity": "sha1-DGwNrt+YM8Kn82I2Bp7+y0w/bl8=",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.1",
-            "jest-get-type": "22.4.3",
-            "pretty-format": "23.0.1"
-          }
-        },
-        "jest-message-util": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.0.0.tgz",
-          "integrity": "sha1-Bz89dscB98cYpLmvHrfxOHksR5Y=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "7.0.0-beta.42",
-            "chalk": "2.3.1",
-            "micromatch": "2.3.11",
-            "slash": "1.0.0",
-            "stack-utils": "1.0.1"
-          }
-        },
-        "jest-regex-util": {
-          "version": "23.0.0",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
-          "integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
-          "dev": true
-        },
-        "jest-resolve": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.0.1.tgz",
-          "integrity": "sha1-P4QDRisQo0wt8dR6q1V0xJNbzSQ=",
-          "dev": true,
-          "requires": {
-            "browser-resolve": "1.11.2",
-            "chalk": "2.3.1",
-            "realpath-native": "1.0.0"
-          }
-        },
-        "jest-serializer": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-          "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
-          "dev": true
-        },
-        "jest-snapshot": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.0.1.tgz",
-          "integrity": "sha1-ZnT6Gbnraamcq+zUFb3cQtavPn4=",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.1",
-            "jest-diff": "23.0.1",
-            "jest-matcher-utils": "23.0.1",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "pretty-format": "23.0.1"
-          }
-        },
-        "jest-util": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.0.1.tgz",
-          "integrity": "sha1-aOpb1+2xd9MFn5eXJZ+ODazOL5k=",
-          "dev": true,
-          "requires": {
-            "callsites": "2.0.0",
-            "chalk": "2.3.1",
-            "graceful-fs": "4.1.11",
-            "is-ci": "1.1.0",
-            "jest-message-util": "23.0.0",
-            "mkdirp": "0.5.1",
-            "source-map": "0.6.1"
-          }
-        },
-        "jest-worker": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.0.1.tgz",
-          "integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
-          "dev": true,
-          "requires": {
-            "merge-stream": "1.0.1"
-          }
-        },
-        "pretty-format": {
-          "version": "23.0.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
-          "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0",
-            "ansi-styles": "3.2.1"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "yargs": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          }
         }
       }
     },
@@ -4807,6 +4184,26 @@
             "ansi-styles": "3.2.1"
           }
         }
+      }
+    },
+    "jest-watcher": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.1.0.tgz",
+      "integrity": "sha1-qNWELjjZ+0r/+CPfartCpYrmzb0=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.1",
+        "string-length": "2.0.0"
+      }
+    },
+    "jest-worker": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.0.1.tgz",
+      "integrity": "sha1-nmSd2WP/QEYCb5HEAX8Dmmqkp7w=",
+      "dev": true,
+      "requires": {
+        "merge-stream": "1.0.1"
       }
     },
     "js-tokens": {
@@ -5702,6 +5099,33 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.1.tgz",
       "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.0.1.tgz",
+      "integrity": "sha1-1h0GUmjkx1kIO8y8onoBrXx2AfQ=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
     },
     "private": {
       "version": "0.1.8",
@@ -6607,6 +6031,24 @@
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.0.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "source-map-url": {
@@ -7715,6 +7157,65 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "2.1.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "2.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "9.0.2"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.7.0",
     "growl": "1.10.5",
-    "jest": "23.0.1",
+    "jest": "23.1.0",
     "pre-commit": "1.2.2",
     "prettier": "^1.12.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1048,15 +1048,15 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expect@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-23.0.1.tgz#99131f2fd9115595f8cc3697401e7f0734d45fef"
+expect@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-23.1.0.tgz#bfdfd57a2a20170d875999ee9787cc71f01c205f"
   dependencies:
     ansi-styles "^3.2.0"
     jest-diff "^23.0.1"
     jest-get-type "^22.1.0"
     jest-matcher-utils "^23.0.1"
-    jest-message-util "^23.0.0"
+    jest-message-util "^23.1.0"
     jest-regex-util "^23.0.0"
 
 extend-shallow@^2.0.1:
@@ -1865,9 +1865,9 @@ jest-changed-files@^23.0.1:
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.0.1.tgz#351a5ba51cf28ecf20336d97a30b970d1f530a56"
+jest-cli@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.1.0.tgz#eb8bdd4ce0d15250892e31ad9b69bc99d2a8f6bf"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
@@ -1881,18 +1881,19 @@ jest-cli@^23.0.1:
     istanbul-lib-instrument "^1.10.1"
     istanbul-lib-source-maps "^1.2.4"
     jest-changed-files "^23.0.1"
-    jest-config "^23.0.1"
-    jest-environment-jsdom "^23.0.1"
+    jest-config "^23.1.0"
+    jest-environment-jsdom "^23.1.0"
     jest-get-type "^22.1.0"
-    jest-haste-map "^23.0.1"
-    jest-message-util "^23.0.0"
+    jest-haste-map "^23.1.0"
+    jest-message-util "^23.1.0"
     jest-regex-util "^23.0.0"
     jest-resolve-dependencies "^23.0.1"
-    jest-runner "^23.0.1"
-    jest-runtime "^23.0.1"
+    jest-runner "^23.1.0"
+    jest-runtime "^23.1.0"
     jest-snapshot "^23.0.1"
-    jest-util "^23.0.1"
+    jest-util "^23.1.0"
     jest-validate "^23.0.1"
+    jest-watcher "^23.1.0"
     jest-worker "^23.0.1"
     micromatch "^2.3.11"
     node-notifier "^5.2.1"
@@ -1904,21 +1905,21 @@ jest-cli@^23.0.1:
     which "^1.2.12"
     yargs "^11.0.0"
 
-jest-config@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.0.1.tgz#6798bff1247c7a390b1327193305001582fc58fa"
+jest-config@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.1.0.tgz#708ca0f431d356ee424fb4895d3308006bdd8241"
   dependencies:
     babel-core "^6.0.0"
     babel-jest "^23.0.1"
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^23.0.1"
-    jest-environment-node "^23.0.1"
+    jest-environment-jsdom "^23.1.0"
+    jest-environment-node "^23.1.0"
     jest-get-type "^22.1.0"
-    jest-jasmine2 "^23.0.1"
+    jest-jasmine2 "^23.1.0"
     jest-regex-util "^23.0.0"
-    jest-resolve "^23.0.1"
-    jest-util "^23.0.1"
+    jest-resolve "^23.1.0"
+    jest-util "^23.1.0"
     jest-validate "^23.0.1"
     pretty-format "^23.0.1"
 
@@ -1937,35 +1938,35 @@ jest-docblock@^23.0.1:
   dependencies:
     detect-newline "^2.1.0"
 
-jest-each@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.0.1.tgz#a6e5dbf530afc6bf9d74792dde69d8db70f84706"
+jest-each@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.1.0.tgz#16146b592c354867a5ae5e13cdf15c6c65b696c6"
   dependencies:
     chalk "^2.0.1"
     pretty-format "^23.0.1"
 
-jest-environment-jsdom@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.0.1.tgz#da689eb9358dc16e5708abb208f4eb26a439575c"
+jest-environment-jsdom@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.1.0.tgz#85929914e23bed3577dac9755f4106d0697c479c"
   dependencies:
-    jest-mock "^23.0.1"
-    jest-util "^23.0.1"
+    jest-mock "^23.1.0"
+    jest-util "^23.1.0"
     jsdom "^11.5.1"
 
-jest-environment-node@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.0.1.tgz#676b740e205f1f2be77241969e7812be824ee795"
+jest-environment-node@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.1.0.tgz#452c0bf949cfcbbacda1e1762eeed70bc784c7d5"
   dependencies:
-    jest-mock "^23.0.1"
-    jest-util "^23.0.1"
+    jest-mock "^23.1.0"
+    jest-util "^23.1.0"
 
 jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
-jest-haste-map@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.0.1.tgz#cd89052abfc8cba01f560bbec09d4f36aec25d4f"
+jest-haste-map@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.1.0.tgz#18e6c7d5a8d27136f91b7d9852f85de0c7074c49"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
@@ -1975,20 +1976,20 @@ jest-haste-map@^23.0.1:
     micromatch "^2.3.11"
     sane "^2.0.0"
 
-jest-jasmine2@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.0.1.tgz#16d875356e6360872bba48426f7d31fdc1b0bcea"
+jest-jasmine2@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.1.0.tgz#4afab31729b654ddcd2b074add849396f13b30b8"
   dependencies:
     chalk "^2.0.1"
     co "^4.6.0"
-    expect "^23.0.1"
+    expect "^23.1.0"
     is-generator-fn "^1.0.0"
     jest-diff "^23.0.1"
-    jest-each "^23.0.1"
+    jest-each "^23.1.0"
     jest-matcher-utils "^23.0.1"
-    jest-message-util "^23.0.0"
+    jest-message-util "^23.1.0"
     jest-snapshot "^23.0.1"
-    jest-util "^23.0.1"
+    jest-util "^23.1.0"
     pretty-format "^23.0.1"
 
 jest-leak-detector@^23.0.1:
@@ -2005,9 +2006,9 @@ jest-matcher-utils@^23.0.1:
     jest-get-type "^22.1.0"
     pretty-format "^23.0.1"
 
-jest-message-util@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.0.0.tgz#073f3d76c701f7c718a4b9af1eb7f138792c4796"
+jest-message-util@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.1.0.tgz#9a809ba487ecac5ce511d4e698ee3b5ee2461ea9"
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.35"
     chalk "^2.0.1"
@@ -2015,9 +2016,9 @@ jest-message-util@^23.0.0:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.0.1.tgz#1569f477968c668fc728273a17c3767773b46357"
+jest-mock@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.1.0.tgz#a381c31b121ab1f60c462a2dadb7b86dcccac487"
 
 jest-regex-util@^23.0.0:
   version "23.0.0"
@@ -2030,35 +2031,35 @@ jest-resolve-dependencies@^23.0.1:
     jest-regex-util "^23.0.0"
     jest-snapshot "^23.0.1"
 
-jest-resolve@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.0.1.tgz#3f8403462b10a34c2df1d47aab5574c4935bcd24"
+jest-resolve@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.1.0.tgz#b9e316eecebd6f00bc50a3960d1527bae65792d2"
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
     realpath-native "^1.0.0"
 
-jest-runner@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.0.1.tgz#b176ae3ecf9e194aa4b84a7fcf70d1b8db231aa7"
+jest-runner@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.1.0.tgz#fa20a933fff731a5432b3561e7f6426594fa29b5"
   dependencies:
     exit "^0.1.2"
     graceful-fs "^4.1.11"
-    jest-config "^23.0.1"
+    jest-config "^23.1.0"
     jest-docblock "^23.0.1"
-    jest-haste-map "^23.0.1"
-    jest-jasmine2 "^23.0.1"
+    jest-haste-map "^23.1.0"
+    jest-jasmine2 "^23.1.0"
     jest-leak-detector "^23.0.1"
-    jest-message-util "^23.0.0"
-    jest-runtime "^23.0.1"
-    jest-util "^23.0.1"
+    jest-message-util "^23.1.0"
+    jest-runtime "^23.1.0"
+    jest-util "^23.1.0"
     jest-worker "^23.0.1"
     source-map-support "^0.5.6"
     throat "^4.0.0"
 
-jest-runtime@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.0.1.tgz#b1d765fb03fb6d4043805af270676a693f504d57"
+jest-runtime@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.1.0.tgz#b4ae0e87259ecacfd4a884b639db07cf4dd620af"
   dependencies:
     babel-core "^6.0.0"
     babel-plugin-istanbul "^4.1.6"
@@ -2067,13 +2068,13 @@ jest-runtime@^23.0.1:
     exit "^0.1.2"
     fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-config "^23.0.1"
-    jest-haste-map "^23.0.1"
-    jest-message-util "^23.0.0"
+    jest-config "^23.1.0"
+    jest-haste-map "^23.1.0"
+    jest-message-util "^23.1.0"
     jest-regex-util "^23.0.0"
-    jest-resolve "^23.0.1"
+    jest-resolve "^23.1.0"
     jest-snapshot "^23.0.1"
-    jest-util "^23.0.1"
+    jest-util "^23.1.0"
     jest-validate "^23.0.1"
     micromatch "^2.3.11"
     realpath-native "^1.0.0"
@@ -2097,16 +2098,17 @@ jest-snapshot@^23.0.1:
     natural-compare "^1.4.0"
     pretty-format "^23.0.1"
 
-jest-util@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.0.1.tgz#68ea5bd7edb177d3059f9797259f8e0dacce2f99"
+jest-util@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.1.0.tgz#c0251baf34644c6dd2fea78a962f4263ac55772d"
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.11"
     is-ci "^1.0.10"
-    jest-message-util "^23.0.0"
+    jest-message-util "^23.1.0"
     mkdirp "^0.5.1"
+    slash "^1.0.0"
     source-map "^0.6.0"
 
 jest-validate@^23.0.1:
@@ -2118,18 +2120,26 @@ jest-validate@^23.0.1:
     leven "^2.1.0"
     pretty-format "^23.0.1"
 
+jest-watcher@^23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.1.0.tgz#a8d5842e38d9fb4afff823df6abb42a58ae6cdbd"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    string-length "^2.0.0"
+
 jest-worker@^23.0.1:
   version "23.0.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.0.1.tgz#9e649dd963ff4046026f91c4017f039a6aa4a7bc"
   dependencies:
     merge-stream "^1.0.1"
 
-jest@23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-23.0.1.tgz#0d083290ee4112cecfb780df6ff81332ed373201"
+jest@23.1.0:
+  version "23.1.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-23.1.0.tgz#bbb7f893100a11a742dd8bd0d047a54b0968ad1a"
   dependencies:
     import-local "^1.0.0"
-    jest-cli "^23.0.1"
+    jest-cli "^23.1.0"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This Pull Request updates dependency [jest](https://github.com/facebook/jest) from `v23.0.1` to `v23.1.0`



<details>
<summary>Release Notes</summary>

### [`v23.1.0`](https://github.com/facebook/jest/blob/master/CHANGELOG.md#&#8203;2310)
[Compare Source](https://github.com/facebook/jest/compare/v23.0.1...v23.1.0)
##### Features

- `[jest-each]` Add pretty-format serialising to each titles ([#&#8203;6357](`https://github.com/facebook/jest/pull/6357`))
- `[jest-cli]` shouldRunTestSuite watch hook now receives an object with `config`, `testPath` and `duration` ([#&#8203;6350](`https://github.com/facebook/jest/pull/6350`))
- `[jest-each]` Support one dimensional array of data ([#&#8203;6351](`https://github.com/facebook/jest/pull/6351`))
- `[jest-watch]` create new package `jest-watch` to ease custom watch plugin development ([#&#8203;6318](`https://github.com/facebook/jest/pull/6318`))
- `[jest-circus]` Make hooks in empty describe blocks error ([#&#8203;6320](`https://github.com/facebook/jest/pull/6320`))
- Add a config/CLI option `errorOnDeprecated` which makes calling deprecated APIs throw hepful error messages ([#&#8203;6339](`https://github.com/facebook/jest/pull/6339`))
##### Fixes

- `[jest-each]` Fix pluralising missing arguments error ([#&#8203;6369](`https://github.com/facebook/jest/pull/6369`))
- `[jest-each]` Stop test title concatenating extra args ([#&#8203;6346](`https://github.com/facebook/jest/pull/6346`))
- `[expect]` toHaveBeenNthCalledWith/nthCalledWith gives wrong call messages if not matched ([#&#8203;6340](`https://github.com/facebook/jest/pull/6340`))
- `[jest-each]` Make sure invalid arguments to `each` points back to the user's code ([#&#8203;6347](`https://github.com/facebook/jest/pull/6347`))
- `[expect]` toMatchObject throws TypeError when a source property is null ([#&#8203;6313](`https://github.com/facebook/jest/pull/6313`))
- `[jest-cli]` Normalize slashes in paths in CLI output on Windows ([#&#8203;6310](`https://github.com/facebook/jest/pull/6310`))
- `[jest-cli]` Fix run beforeAll in excluded suites tests" mode. ([#&#8203;6234](`https://github.com/facebook/jest/pull/6234`))
- `[jest-haste-map`] Compute SHA-1s for non-tracked files when using Node crawler ([#&#8203;6264](`https://github.com/facebook/jest/pull/6264`))
##### Chore & Maintenance

- `[docs]` Improve documentation of `mockClear`, `mockReset`, and `mockRestore` ([#&#8203;6227](`https://github.com/facebook/jest/pull/6227`/files))
- `[jest-circus]` Add dependency on jest-each ([#&#8203;6309](https://github.com/facebook/jest/pull/#&#8203;6309))
- `[jest-each]` Refactor each to use shared implementation with core ([#&#8203;6345](`https://github.com/facebook/jest/pull/6345`))
- `[jest-each]` Update jest-each docs for serialising values into titles ([#&#8203;6337](`https://github.com/facebook/jest/pull/6337`))
- `[jest-circus]` Add dependency on jest-each ([#&#8203;6309](`https://github.com/facebook/jest/pull/6309`))
- `[filenames]` Rename "integration-tests" to "e2e" ([#&#8203;6315](`https://github.com/facebook/jest/pull/6315`))
- `[docs]` Mention the use of commit hash with `--changedSince` flag ([#&#8203;6330](`https://github.com/facebook/jest/pull/6330`))

---

</details>