### PR TITLE
Bump github/codeql-action/upload-sarif from v1 to v2

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -45,6 +45,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
version 1 of the CodeQL Action was deprecated

see https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated